### PR TITLE
[SC] only initialize video once

### DIFF
--- a/src/modules/Navigation/index.js
+++ b/src/modules/Navigation/index.js
@@ -27,7 +27,9 @@ const Navigation = ({ isHomepage = false, children }) => {
         setTimeout(() => {
             video && typeof video.play === "function" && video.play();
         }, LOAD_DELAY);
+    }, []);
 
+    useEffect(() => {
         function reportScrollY() {
             if (!isHomepage) {
                 return;


### PR DESCRIPTION
didn't notice in dev, but the video play call was running every 1.5 seconds. Some quick reading on Hooks revealed you can call multiple `useEffect` hooks in a single component, and you can skip re-execution with the 2nd param.

https://reactjs.org/docs/hooks-effect.html#tip-optimizing-performance-by-skipping-effects