### PR TITLE
adopt React.lazy for route-level splitting

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,31 +1,34 @@
 import "react-app-polyfill/ie11";
-import React from "react";
+import React, { Suspense, lazy } from "react";
 import { render } from "react-snapshot";
 import { BrowserRouter as Router, Switch, Route, Redirect } from "react-router-dom";
 import Footer from "./modules/Footer";
 import Homepage from "./pages/homepage";
-import Puzzles from "./pages/puzzles";
-import Puzzle from "./pages/puzzle";
-import Cocktails from "./pages/cocktails";
-import Error from "./pages/error";
 import registerServiceWorker from "./registerServiceWorker";
 import "./index.scss";
 
+const Puzzles = lazy(() => import("./pages/puzzles"));
+const Puzzle = lazy(() => import("./pages/puzzle"));
+const Cocktails = lazy(() => import("./pages/cocktails"));
+const Error = lazy(() => import("./pages/error"));
+
 const Sitemap = (): JSX.Element => (
-    <Router>
-        <main className="page">
-            <Switch>
-                <Route path="/" exact component={ Homepage } />
-                <Redirect from="/puzzle" exact to="/puzzles" />
-                <Route path="/puzzles" exact component={ Puzzles } />
-                <Route path="/puzzle/:puzzleName" exact component={ Puzzle } />
-                <Redirect from="/cocktail" exact to="/cocktails" />
-                <Route path="/cocktails" exact component={ Cocktails } />
-                <Route path="*" render={ (): JSX.Element => <Error errorCode={ 404 } /> } />
-            </Switch>
-            <Footer />
-        </main>
-    </Router>
+    <Suspense fallback={ <div>Loading...</div> }>
+        <Router>
+            <main className="page">
+                <Switch>
+                    <Route path="/" exact component={ Homepage } />
+                    <Redirect from="/puzzle" exact to="/puzzles" />
+                    <Route path="/puzzles" exact component={ Puzzles } />
+                    <Route path="/puzzle/:puzzleName" exact component={ Puzzle } />
+                    <Redirect from="/cocktail" exact to="/cocktails" />
+                    <Route path="/cocktails" exact component={ Cocktails } />
+                    <Route path="*" render={ (): JSX.Element => <Error errorCode={ 404 } /> } />
+                </Switch>
+                <Footer />
+            </main>
+        </Router>
+    </Suspense>
 );
 
 render(<Sitemap />, document.getElementById("root"));


### PR DESCRIPTION
![split bundle](https://user-images.githubusercontent.com/2357930/76054749-af7cee00-5f3f-11ea-8c46-38c83926abdb.png)
All (101.06 KB)
static/js/3.959992f0.chunk.js (63.46 KB)
static/js/main.9ca90e7b.chunk.js (26.48 KB)
static/js/0.cc585a85.chunk.js (7.38 KB)
static/js/runtime-main.0d7202dc.js (1.53 KB)
static/js/4.43b88731.chunk.js (1.1 KB)
static/js/6.d3e8a6c0.chunk.js (756 B)
static/js/5.324aaecc.chunk.js (383 B)

versus current:
All (97.95 KB)
static/js/2.b55f7f6a.chunk.js (65.67 KB)
static/js/main.98945e49.chunk.js (31.53 KB)
static/js/runtime-main.ad264d5c.js (772 B)

NOTE: This currently does not work with `react-snapshot` which is being used for mock SSR